### PR TITLE
fix(gatsby docs): add x-transport on servers to default inspector transport

### DIFF
--- a/templates/docs/gatsby/_package.json
+++ b/templates/docs/gatsby/_package.json
@@ -4,7 +4,7 @@
   "description": "",
   "version": "0.0.0-development",
   "dependencies": {
-    "@open-rpc/inspector": "^1.4.2",
+    "@open-rpc/inspector": "^1.4.7",
     "react-split-pane": "^0.1.87",
     "monaco-editor": "0.18.1",
     "@apidevtools/json-schema-ref-parser": "^9.0.1",

--- a/templates/docs/gatsby/src/pages/api-documentation.tsx
+++ b/templates/docs/gatsby/src/pages/api-documentation.tsx
@@ -62,6 +62,7 @@ const ApiDocumentation: React.FC = () => {
   `);
   const [openrpcDocument, setOpenrpcDocument] = useState<OpenrpcDocument>();
   const [inspectorUrl, setInspectorUrl] = useState<string>();
+  const [inspectorTransport, setInspectorTransport] = useState<string>();
 
   useEffect(() => {
     if (openrpcQueryData.openrpcDocument) {
@@ -70,8 +71,14 @@ const ApiDocumentation: React.FC = () => {
   }, [openrpcQueryData]);
 
   useEffect(() => {
-    if (openrpcDocument && openrpcDocument.servers && openrpcDocument.servers[0]) {
+    if (!openrpcDocument) {
+      return;
+    }
+    if (openrpcDocument.servers && openrpcDocument.servers[0]) {
       setInspectorUrl(openrpcDocument.servers[0].url);
+      if (openrpcDocument.servers[0]["x-transport"]) {
+        setInspectorTransport(openrpcDocument.servers[0]["x-transport"]);
+      }
     }
   }, [openrpcDocument])
 
@@ -93,6 +100,7 @@ const ApiDocumentation: React.FC = () => {
       right={
         <Inspector
           url={inspectorUrl}
+          transport={inspectorTransport}
           hideToggleTheme={true}
           openrpcDocument={openrpcDocument}
           darkMode={darkmode.value}


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/364566/88221702-b6b84600-cc19-11ea-8250-3f9157dace17.png)


![image](https://user-images.githubusercontent.com/364566/88221658-a902c080-cc19-11ea-9f22-e4bc5b349e9d.png)
