### PR TITLE
fix: Typescript error in ts client template

### DIFF
--- a/src/components/client.ts
+++ b/src/components/client.ts
@@ -129,7 +129,7 @@ export class <%= className %> {
   }
 
   private request(methodName: string, params: any[]): Promise<any> {
-    const methodObject = _.find(<%= className %>.openrpcDocument.methods, ({name}: MethodObject) => name === methodName) as MethodObject;
+    const methodObject = _.find(<%= className %>.openrpcDocument.methods, ({name}: MethodObject) => name === methodName) as MethodObject; 
     const notification = methodObject.result ? false : true;
     const openRpcMethodValidationErrors = this.validator.validate(methodName, params);
     if ( openRpcMethodValidationErrors instanceof MethodNotFoundError || openRpcMethodValidationErrors.length > 0) {

--- a/src/components/client.ts
+++ b/src/components/client.ts
@@ -129,7 +129,7 @@ export class <%= className %> {
   }
 
   private request(methodName: string, params: any[]): Promise<any> {
-    const methodObject = _.find(<%= className %>.openrpcDocument.methods, ({name}) => name === methodName) as MethodObject;
+    const methodObject = _.find(<%= className %>.openrpcDocument.methods, ({name}: MethodObject) => name === methodName) as MethodObject;
     const notification = methodObject.result ? false : true;
     const openRpcMethodValidationErrors = this.validator.validate(methodName, params);
     if ( openRpcMethodValidationErrors instanceof MethodNotFoundError || openRpcMethodValidationErrors.length > 0) {


### PR DESCRIPTION
At its current state, live 132 gives an error `Property 'name' does not exist on type 'MethodReference'`. Its caused by type declaration of `MethodReference`:
```javascript
export type MethodReference = MethodObject | ReferenceObject;
export type Methods = MethodReference[];
```
when destructing MethodReference, because there is no `name` in `ReferenceObject`.
But we know for sure, that there are only `MethodObject`s elements in that array, so we can just explicitly specify the type `MethodObject`.